### PR TITLE
Implement listing destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ DiscountNetwork::Session.create(
 )
 ```
 
+### Destination
+
+#### List destinations
+
+Retrieve the list of destinations based on a search term. This is useful when
+you are planning to show the list of destinations while user start to type
+destination name
+
+```ruby
+DiscountNetwork::Destination.list(term: "bangkok")
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/discountnetwork.rb
+++ b/lib/discountnetwork.rb
@@ -2,6 +2,7 @@ require "discountnetwork/version"
 require "discountnetwork/client"
 require "discountnetwork/session"
 require "discountnetwork/search"
+require "discountnetwork/destination"
 
 module DiscountNetwork
 end

--- a/lib/discountnetwork/client.rb
+++ b/lib/discountnetwork/client.rb
@@ -40,6 +40,10 @@ module DiscountNetwork
     end
   end
 
+  def self.get_resource(end_point, attributes)
+    Client.new(:get, end_point, attributes).execute
+  end
+
   def self.post_resource(end_point, attributes)
     Client.new(:post, end_point, attributes).execute
   end

--- a/lib/discountnetwork/destination.rb
+++ b/lib/discountnetwork/destination.rb
@@ -1,0 +1,9 @@
+module DiscountNetwork
+  class Destination
+    def self.list(term:)
+      DiscountNetwork.get_resource(
+        "destinations", term: term
+      )
+    end
+  end
+end

--- a/lib/discountnetwork/testing/discountnetwork_api.rb
+++ b/lib/discountnetwork/testing/discountnetwork_api.rb
@@ -25,6 +25,16 @@ module DiscountNetworkApi
     )
   end
 
+  def stub_destination_list_api(term:)
+    stub_api_response(
+      :get,
+      "destinations",
+      data: { term: term },
+      filename: "destinations",
+      status: 200
+    )
+  end
+
   private
 
   def api_end_point(end_point)

--- a/spec/discountnetwork/client_spec.rb
+++ b/spec/discountnetwork/client_spec.rb
@@ -10,6 +10,15 @@ describe DiscountNetwork::Client do
     end
   end
 
+  describe ".get_resource" do
+    it "requests the resource via :get" do
+      stub_discountnetwork_ping_request(:get, request_data)
+      response = DiscountNetwork.get_resource("ping", request_data)
+
+      expect(response.data).to eq("Pong!")
+    end
+  end
+
   def request_data
     { content: "Ping Request" }
   end

--- a/spec/discountnetwork/destination_spec.rb
+++ b/spec/discountnetwork/destination_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+describe DiscountNetwork::Destination do
+  describe ".list" do
+    it "returns the similar destinations" do
+      search_term = "bang"
+      stub_destination_list_api(term: search_term)
+
+      destinations = DiscountNetwork::Destination.list(term: search_term)
+      destination = destinations.first
+
+      expect(destination.value).to eq(835)
+      expect(destination.label).to eq("Bangkok, Thailand")
+    end
+  end
+end

--- a/spec/fixtures/destinations.json
+++ b/spec/fixtures/destinations.json
@@ -1,0 +1,22 @@
+[
+  {
+    "label": "Bangkok, Thailand",
+    "value": 835
+  },
+  {
+    "label": "Bangalore, India",
+    "value": 866
+  },
+  {
+    "label": "Dhaka, Bangladesh",
+    "value": 1715
+  },
+  {
+    "label": "Bangka, Indonesia",
+    "value": 26064
+  },
+  {
+    "label": "Sylhet, Bangladesh",
+    "value": 28031
+  }
+]


### PR DESCRIPTION
Discount Network API requires to map the user entered destinations to the provider specified ids. This implementation adds and easier way to retrieve the destinations based on the user entered term.
