### PR TITLE
Add retrieving search details

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,34 @@ destination name
 DiscountNetwork::Destination.list(term: "bangkok")
 ```
 
+### Search
+
+#### Create new search
+
+You can create a new search using the API. Please note: It's advisable to wait
+10-15 seconds before trying to retrieve the search results.
+
+```ruby
+DiscountNetwork::Search.create(
+  adults: 2,
+  children: 0,
+  room_numbers: 1
+  location_id: 835,
+  check_in: "25/10/2016",
+  check_out: "28/10/2016",
+  location_name: "Bangkok, Thailand",
+)
+```
+
+#### Retrieve search details
+
+Once, you have created a new search and you have the search id then you can
+retrieve the search details as
+
+```ruby
+DiscountNetwork::Search.find(search_id)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/discountnetwork/client.rb
+++ b/lib/discountnetwork/client.rb
@@ -40,7 +40,7 @@ module DiscountNetwork
     end
   end
 
-  def self.get_resource(end_point, attributes)
+  def self.get_resource(end_point, attributes = {})
     Client.new(:get, end_point, attributes).execute
   end
 

--- a/lib/discountnetwork/search.rb
+++ b/lib/discountnetwork/search.rb
@@ -5,5 +5,11 @@ module DiscountNetwork
         "searches", search: search_params
       )
     end
+
+    def self.find(search_id)
+      DiscountNetwork.get_resource(
+        ["searches", search_id].join("/")
+      ).search
+    end
   end
 end

--- a/lib/discountnetwork/testing/discountnetwork_api.rb
+++ b/lib/discountnetwork/testing/discountnetwork_api.rb
@@ -35,6 +35,15 @@ module DiscountNetworkApi
     )
   end
 
+  def stub_search_find_api(search_id)
+    stub_api_response(
+      :get,
+      ["searches", search_id].join("/"),
+      filename: "search",
+      status: 200
+    )
+  end
+
   private
 
   def api_end_point(end_point)

--- a/spec/discountnetwork/search_spec.rb
+++ b/spec/discountnetwork/search_spec.rb
@@ -12,6 +12,17 @@ describe DiscountNetwork::Search do
     end
   end
 
+  describe ".find" do
+    it "finds the specified search" do
+      search_id = "DN_SEARCH_101"
+      stub_search_find_api(search_id)
+      search = DiscountNetwork::Search.find(search_id)
+
+      expect(search.id).to eq(search_id)
+      expect(search.location).to eq("Bangkok, Thailand")
+    end
+  end
+
   def search_params
     @search_params ||= {
       location_id: "835",

--- a/spec/fixtures/search.json
+++ b/spec/fixtures/search.json
@@ -1,0 +1,19 @@
+{
+  "search": {
+    "id": "DN_SEARCH_101",
+    "location": "Bangkok, Thailand",
+    "check_in": "26 August, 2016",
+    "check_out": "28 August, 2016",
+    "adults": 2,
+    "children": 0,
+    "total_rooms": 0,
+    "dmy_check_in": "26/08/2016",
+    "dmy_check_out": "28/08/2016",
+    "total_results": 0,
+    "min_price": null,
+    "last_provider": null,
+    "max_provider": 2,
+    "status": null,
+    "wait_time": -173
+  }
+}


### PR DESCRIPTION
User retrieves search details based on the `search_id`. This commit adds an easier interface to retrieve search details as simple as:

``` ruby
DiscountNetwork::Search.find(search_id)
```
