### PR TITLE
Retrieve a specific hotel details

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,16 @@ DiscountNetwork::Result.where(
 )
 ```
 
+#### Retrieve a hotel details
+
+Retrieve the hotel details for a specific search
+
+```ruby
+DiscountNetwork::Result.find_by(
+  search_id: search_id, hotel_id: hotel_id
+)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/discountnetwork/result.rb
+++ b/lib/discountnetwork/result.rb
@@ -5,5 +5,11 @@ module DiscountNetwork
         ["searches", search_id, "results"].join("/"), attributes
       ).result
     end
+
+    def self.find_by(search_id:, hotel_id:, **attributes)
+      DiscountNetwork.get_resource(
+        ["searches", search_id, "results", hotel_id].join("/"), attributes
+      ).result
+    end
   end
 end

--- a/lib/discountnetwork/testing/discountnetwork_api.rb
+++ b/lib/discountnetwork/testing/discountnetwork_api.rb
@@ -53,6 +53,15 @@ module DiscountNetworkApi
     )
   end
 
+  def stub_search_result_api(search_id:, hotel_id:)
+    stub_api_response(
+      :get,
+      ["searches", search_id, "results", hotel_id].join("/"),
+      filename: "result",
+      status: 200
+    )
+  end
+
   private
 
   def api_end_point(end_point)

--- a/spec/discountnetwork/result_spec.rb
+++ b/spec/discountnetwork/result_spec.rb
@@ -12,4 +12,19 @@ describe DiscountNetwork::Result do
       expect(results.hotels.first.name).to eq("Nasa Vegas Hotel")
     end
   end
+
+  describe ".find_by" do
+    it "retrieves the hotel details for a specific search" do
+      search_id = 123_456_789
+      hotel_id = 456_789_012
+      stub_search_result_api(search_id: search_id, hotel_id: hotel_id)
+      hotel = DiscountNetwork::Result.find_by(
+        search_id: search_id, hotel_id: hotel_id
+      )
+
+      expect(hotel.id).to eq(hotel_id)
+      expect(hotel.search.id).to eq(search_id)
+      expect(hotel.name).to eq("Nasa Vegas Hotel")
+    end
+  end
 end

--- a/spec/fixtures/result.json
+++ b/spec/fixtures/result.json
@@ -1,0 +1,89 @@
+{
+  "result": {
+    "id": 456789012,
+    "name": "Nasa Vegas Hotel",
+    "description": "Nasa Vegas Hotel is conveniently located in the popular Ratchadaphisek area. The hotel offers a high standard of service and amenities to suit the individual needs of all travelers. Meeting facilities, restaurant are just some of the facilities on offer. Each guestroom is elegantly furnished and equipped with handy amenities. Recuperate from a full day of sightseeing in the comfort of your room or take advantage of the hotel's recreational facilities, including fitness center. No matter what your reasons are for visiting Bangkok, Nasa Vegas Hotel will make you feel instantly at home.",
+    "website": "/hotels/thailand/bangkok/nasa-vegas-hotel-35296",
+    "address": "44 Sukhumvit 71-Ramkhamhaeng Road",
+    "latitude": 13.74298,
+    "longitude": 100.60189,
+    "property_type": null,
+    "stars": 3,
+    "rank": 1,
+    "price": 19,
+    "total_reviews": 14218,
+    "review_score": 71,
+    "image": "http://1.omg.io/wego/image/upload/w_200,h_200,c_fill/v1412203579/hotels/35296/18982289.jpg",
+    "review_text": "Fair",
+    "offer": null,
+    "promo_price": 14.3469,
+    "currency_code": "USD",
+    "check_in": "15:00:00",
+    "check_out": "12:00:00",
+    "postal_code": "10250",
+    "fax": "reservation@nasavegashotel.com",
+    "reservation_phone": "+6627199888",
+    "cancellation_policy": {
+      "table": {}
+    },
+    "videos": [],
+    "images": [
+      "http://0.omg.io/wego/image/upload/w_460,h_460,c_fill/v1428174470/hotels/35296/13560731.jpg",
+      "http://0.omg.io/wego/image/upload/w_460,h_460,c_fill/v1428174557/hotels/35296/5887465.jpg",
+      "http://1.omg.io/wego/image/upload/w_460,h_460,c_fill/v1412203706/hotels/35296/10311481.jpg",
+      "http://0.omg.io/wego/image/upload/w_460,h_460,c_fill/v1412203552/hotels/35296/35681515.jpg",
+      "http://0.omg.io/wego/image/upload/w_460,h_460,c_fill/v1412203552/hotels/35296/35681502.jpg"
+    ],
+    "property_amenities": [
+      "Restaurant",
+      "Massage services",
+      "Meeting rooms",
+      "Playground"
+    ],
+    "room_amenities": [
+      "Bathrobe",
+      "Cable television",
+      "Hairdryer",
+      "Internet access",
+      "Microwave",
+      "Newspaper",
+      "Private pool",
+      "Separate tub and shower"
+    ],
+    "search": {
+      "id": 123456789,
+      "location": null,
+      "check_in": "01 September, 2016",
+      "check_out": "03 September, 2016",
+      "adults": 2,
+      "children": 0,
+      "total_rooms": 0,
+      "dmy_check_in": "01/09/2016",
+      "dmy_check_out": "03/09/2016",
+      "total_results": 0,
+      "min_price": null,
+      "last_provider": null,
+      "max_provider": 2,
+      "status": null,
+      "wait_time": -119
+    },
+    "room_rate": {
+      "table": {
+        "id": "193-1",
+        "price_str": "19",
+        "currency_code": "USD",
+        "currency_sym": "US$",
+        "provider_name": "Expedia.co.th",
+        "provider_code": "expedia.co.th",
+        "mobile_friendly": true,
+        "ex_tax": false,
+        "is_direct": false,
+        "description": "Junior Room Double - Room Only - Non Refundable - Save 63% - NON REFUNDABLE",
+        "phones": null,
+        "amenities": [],
+        "room_left": null
+      },
+      "modifiable": true
+    }
+  }
+}


### PR DESCRIPTION
Before submitting a search request a user needs to retrieve the details for a specific hotel. This commit adds an interface to retrieve the hotel details from a specific search. Usages

``` ruby
DiscountNetwork::Result.find_by(
 search_id: search_id, hotel_id: hotel_id
)
```
