### PR TITLE
Fix the issue with `result_id`

### DIFF
--- a/spec/fixtures/results.json
+++ b/spec/fixtures/results.json
@@ -22,7 +22,7 @@
     "per_page": 5,
     "filtered_count": 1251,
     "hotels": [{
-      "id": 35296,
+      "id": 456789012,
       "name": "Nasa Vegas Hotel",
       "description": "Nasa Vegas Hotel is conveniently located in the popular Ratchadaphisek area. The hotel offers a high standard of service and amenities to suit the individual needs of all travelers. Meeting facilities, restaurant are just some of the facilities on offer. Each guestroom is elegantly furnished and equipped with handy amenities. Recuperate from a full day of sightseeing in the comfort of your room or take advantage of the hotel's recreational facilities, including fitness center. No matter what your reasons are for visiting Bangkok, Nasa Vegas Hotel will make you feel instantly at home.",
       "website": "/hotels/thailand/bangkok/nasa-vegas-hotel-35296",


### PR DESCRIPTION
We advised third party application to use `123456789` as `search_id` and `456789012` as the `result_id` or `hotel_id`, but some of ours fixture still using the old `result_id` which creates confliction. This commit will fixes fixture to return the correct `result_id`
