### PR TITLE
Add support for booking options

### DIFF
--- a/lib/discountnetwork/testing/discountnetwork_api.rb
+++ b/lib/discountnetwork/testing/discountnetwork_api.rb
@@ -74,16 +74,14 @@ module DiscountNetworkApi
 
   private
 
-  def build_booking_data(booking_params)
-    {
-      search_id: booking_params[:search_id].to_s,
-      travellers_attributes: [booking_params[:travellers]],
+  def build_booking_data(search_id:, hotel_id:, travellers:, properties:, **opt)
+    opt.merge(
+      search_id: search_id.to_s,
+      travellers_attributes: [travellers],
       properties_attributes: [
-        booking_params[:properties].merge(
-          property_id: booking_params[:hotel_id].to_s
-        )
+        properties.merge(property_id: hotel_id.to_s)
       ]
-    }
+    )
   end
 
   def api_end_point(end_point)

--- a/spec/discountnetwork/booking_spec.rb
+++ b/spec/discountnetwork/booking_spec.rb
@@ -24,7 +24,8 @@ describe DiscountNetwork::Booking do
       search_id: search_id,
       hotel_id: hotel_id,
       travellers: traveller_attributes,
-      properties: property_attributes
+      properties: property_attributes,
+      note: "This is a special requets"
     }
   end
 


### PR DESCRIPTION
Booking creation helper does not include the additional options for the test helper, which is causing the problem when third party apps try to stub a booking creation API. This commit fixes that issue.
