### PR TITLE
Add interface to find a booking

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,15 @@ property_attributes = {
 }
 ```
 
+### Find a booking
+
+To find the details for a specific booking request, including the confirmation
+number, use
+
+```ruby
+DiscountNetwork::Booking.find(booking_id)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/discountnetwork/booking.rb
+++ b/lib/discountnetwork/booking.rb
@@ -1,5 +1,11 @@
 module DiscountNetwork
   class Booking < Base
+    def find(booking_id)
+      DiscountNetwork.get_resource(
+        ["bookings", booking_id].join("/")
+      ).travel_request
+    end
+
     def create(search_id:, hotel_id:, travellers:, properties:, **attrs)
       attributes = attrs.merge(
         search_id: search_id,

--- a/lib/discountnetwork/testing/discountnetwork_api.rb
+++ b/lib/discountnetwork/testing/discountnetwork_api.rb
@@ -67,7 +67,16 @@ module DiscountNetworkApi
       :post,
       "bookings",
       data: { booking: build_booking_data(booking_params) },
-      filename: "booking_created",
+      filename: "booking",
+      status: 200
+    )
+  end
+
+  def stub_booking_find_api(booking_id)
+    stub_api_response(
+      :get,
+      ["bookings", booking_id].join("/"),
+      filename: "booking",
       status: 200
     )
   end

--- a/spec/discountnetwork/booking_spec.rb
+++ b/spec/discountnetwork/booking_spec.rb
@@ -19,6 +19,19 @@ describe DiscountNetwork::Booking do
     end
   end
 
+  describe ".find" do
+    it "finds the booking details" do
+      booking_id = 123_456_789
+      stub_booking_find_api(booking_id)
+      booking = DiscountNetwork::Booking.find(booking_id)
+
+      expect(booking.id).to eq(booking_id)
+      expect(booking.travel_criteria).not_to be_nil
+      expect(booking.travellers.first).not_to be_nil
+      expect(booking.properties.first).not_to be_nil
+    end
+  end
+
   def build_booking_attributes(search_id, hotel_id)
     {
       search_id: search_id,

--- a/spec/fixtures/booking.json
+++ b/spec/fixtures/booking.json
@@ -1,6 +1,6 @@
 {
   "travel_request": {
-    "id": 295,
+    "id": 123456789,
     "user": {
       "first_name": "Abu",
       "middle_name": "",


### PR DESCRIPTION
Discount Network API provides the booking details so third party app can show that as confirmation or any other purpose they might need. This commit adds an interface to retrieve the booking details from the API. Usages:

``` ruby
DiscountNetwork::Booking.find(booking_id)
```
