### PR TITLE
Add optional account `auth_token`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,18 +57,16 @@ DiscountNetwork::Session.create(
 
 #### Find user account
 
-Once you have created a new session and store the token as `auth_token`
-configuration then you can retrieve the user account details as
+To retrieve the user account details using the Discount Network `account` API
 
 ```ruby
 #
-# It expectes you to set up the `auth_token` configuration
-# before requesting the user account API. If you have not
-# set up the the `auth_token` yet then you can use
+# The `auth_token` is optional, if you don't pass any
+# parameter then it will try to retrieve the subscriber
+# using the `auth_token` configuration.
 #
-# `DiscountNetwork.configuration.auth_token = session_token
 
-DiscountNetwork::Account.find
+DiscountNetwork::Account.find(auth_token)
 ```
 
 ### Destination

--- a/lib/discountnetwork/account.rb
+++ b/lib/discountnetwork/account.rb
@@ -1,6 +1,7 @@
 module DiscountNetwork
   class Account < Base
-    def find
+    def find(auth_token = nil)
+      set_account_auth_token(auth_token)
       if auth_token_exists?
         DiscountNetwork.get_resource("account").user
       end
@@ -10,6 +11,12 @@ module DiscountNetwork
 
     def auth_token_exists?
       !DiscountNetwork.configuration.auth_token.nil?
+    end
+
+    def set_account_auth_token(auth_token)
+      if !auth_token.nil?
+        DiscountNetwork.configuration.auth_token = auth_token
+      end
     end
   end
 end

--- a/spec/discountnetwork/account_spec.rb
+++ b/spec/discountnetwork/account_spec.rb
@@ -7,7 +7,7 @@ describe DiscountNetwork::Account do
       stub_account_find_api(auth_token)
       set_account_auth_token(auth_token)
 
-      account = DiscountNetwork::Account.find
+      account = DiscountNetwork::Account.find(auth_token)
       set_account_auth_token(nil)
 
       expect(account.name).not_to be_nil


### PR DESCRIPTION
In the account find API, we are presuming the `auth_token` is already stored as configuration, but in some use case scenario applications might want to retrieve the account details without setting auth token configuration, so let's change our existing find api and support an option `auth_token` parameters.
