### PR TITLE
Add account activation interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,19 @@ the `activation_token`. To find a `subscriber` use
 DiscountNetwork::Activation.find(activation_token)
 ```
 
+#### Activate a subscriber
+
+Once subscriber has provided their required information then we can activate
+their account using the `Activation` API. The API already has validations in
+place but it would be easier to implement some validation before sending any
+activation API request.
+
+```ruby
+DiscountNetwork::Activation.activate(
+  activation_token, subscriber_attributes
+)
+```
+
 ### Destination
 
 #### List destinations

--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ we can update the user details using the DiscountNetwork `account` API
 DiscountNetwork::Account.update(subscriber_attributes)
 ```
 
+### Activation
+
+#### Find a subscriber
+
+The `activation` offers an easier way to find the subscriber details based on
+the `activation_token`. To find a `subscriber` use
+
+```ruby
+DiscountNetwork::Activation.find(activation_token)
+```
+
 ### Destination
 
 #### List destinations

--- a/lib/discountnetwork.rb
+++ b/lib/discountnetwork.rb
@@ -6,6 +6,7 @@ require "discountnetwork/account"
 require "discountnetwork/search"
 require "discountnetwork/result"
 require "discountnetwork/booking"
+require "discountnetwork/activation"
 require "discountnetwork/destination"
 
 module DiscountNetwork

--- a/lib/discountnetwork/activation.rb
+++ b/lib/discountnetwork/activation.rb
@@ -5,5 +5,11 @@ module DiscountNetwork
         ["account", "activation", token].join("/"),
       ).user
     end
+
+    def activate(token, attributes)
+      DiscountNetwork.put_resource(
+        ["account", "activation", token].join("/"), user: attributes
+      ).user
+    end
   end
 end

--- a/lib/discountnetwork/activation.rb
+++ b/lib/discountnetwork/activation.rb
@@ -1,0 +1,9 @@
+module DiscountNetwork
+  class Activation < Base
+    def find(token)
+      DiscountNetwork.get_resource(
+        ["account", "activation", token].join("/"),
+      ).user
+    end
+  end
+end

--- a/lib/discountnetwork/testing/discountnetwork_api.rb
+++ b/lib/discountnetwork/testing/discountnetwork_api.rb
@@ -102,6 +102,15 @@ module DiscountNetworkApi
     )
   end
 
+  def stub_activation_find_api(token)
+    stub_api_response(
+      :get,
+      ["account", "activation", token].join("/"),
+      filename: "user",
+      status: 200,
+    )
+  end
+
   def stub_unauthorized_dn_api_reqeust(end_point)
     stub_request(:any, api_end_point(end_point)).
       to_return(status: 401, body: "")

--- a/lib/discountnetwork/testing/discountnetwork_api.rb
+++ b/lib/discountnetwork/testing/discountnetwork_api.rb
@@ -111,6 +111,16 @@ module DiscountNetworkApi
     )
   end
 
+  def stub_activation_activate_api(token, attributes)
+    stub_api_response(
+      :put,
+      ["account", "activation", token].join("/"),
+      data: { user: attributes },
+      filename: "user",
+      status: 200,
+    )
+  end
+
   def stub_unauthorized_dn_api_reqeust(end_point)
     stub_request(:any, api_end_point(end_point)).
       to_return(status: 401, body: "")

--- a/spec/discountnetwork/activation_spec.rb
+++ b/spec/discountnetwork/activation_spec.rb
@@ -11,4 +11,36 @@ describe DiscountNetwork::Activation do
       expect(account.token).to eq(token)
     end
   end
+
+  describe ".activate" do
+    it "activates the subscriber account" do
+      token = "ABCD_123"
+      stub_activation_activate_api(token, subscriber_attributes)
+      account = DiscountNetwork::Activation.activate(
+        token, subscriber_attributes
+      )
+
+      expect(account.name).not_to be_nil
+      expect(account.status).to eq("Active")
+    end
+  end
+
+  def subscriber_attributes
+    @subscriber_attributes ||= {
+      first_name: "John",
+      last_name: "Doe",
+      sex: "Male",
+      address: "123 Main Street",
+      city: "New York",
+      zip: "NY123",
+      state: "New York",
+      phone: "+1 123 456 789 0123",
+      mobile: "+1 012 345 678 9012",
+      username: "john.doe",
+      email: "john.doe@example.com",
+      country: "US",
+      password: "secret_password",
+      password_confirmation: "secret_password",
+    }
+  end
 end

--- a/spec/discountnetwork/activation_spec.rb
+++ b/spec/discountnetwork/activation_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+describe DiscountNetwork::Activation do
+  describe ".find" do
+    it "retruns the subscriber account" do
+      token = "ABCD_123"
+      stub_activation_find_api(token)
+      account = DiscountNetwork::Activation.find(token)
+
+      expect(account.name).not_to be_nil
+      expect(account.token).to eq(token)
+    end
+  end
+end


### PR DESCRIPTION
This commit adds an interface to retrieve the subscriber using the account activation token. To find a subscriber use

``` ruby
DiscountNetwork::Activation.find(activation_token)
```
