### PR TITLE
Add `password creation` interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,15 @@ their password using the Discount network API.
 DiscountNetwork::Password.forgot(email_address)
 ```
 
+#### Set new password
+
+Once subscriber has submitted a valid reset request and followed the instruction
+then we can allow them to set their password as follow
+
+```ruby
+DiscountNetwork::Password.create(reset_token, password_attributes)
+```
+
 ### Destination
 
 #### List destinations

--- a/lib/discountnetwork/password.rb
+++ b/lib/discountnetwork/password.rb
@@ -5,5 +5,11 @@ module DiscountNetwork
         "account/resets", account: { email: email }
       )
     end
+
+    def create(token, attributes)
+      DiscountNetwork.put_resource(
+        ["account", "passwords", token].join("/"), account: attributes
+      )
+    end
   end
 end

--- a/lib/discountnetwork/testing/discountnetwork_api.rb
+++ b/lib/discountnetwork/testing/discountnetwork_api.rb
@@ -131,6 +131,16 @@ module DiscountNetworkApi
     )
   end
 
+  def stub_password_create_api(token, attributes)
+    stub_api_response(
+      :put,
+      ["account", "passwords", token].join("/"),
+      data: { account: attributes },
+      filename: "empty",
+      status: 204,
+    )
+  end
+
   def stub_unauthorized_dn_api_reqeust(end_point)
     stub_request(:any, api_end_point(end_point)).
       to_return(status: 401, body: "")

--- a/spec/discountnetwork/password_spec.rb
+++ b/spec/discountnetwork/password_spec.rb
@@ -11,4 +11,20 @@ describe DiscountNetwork::Password do
       expect(password.class).to eq(DiscountNetwork::ResponseObject)
     end
   end
+
+  describe ".create" do
+    it "creates a new password" do
+      token = "ABCD_123"
+      password_attributes = {
+        password: "secret_password",
+        password_confirmation: "secret_password",
+      }
+
+      stub_password_create_api(token, password_attributes)
+      password = DiscountNetwork::Password.create(token, password_attributes)
+
+      expect(password).not_to be_nil
+      expect(password.class).to eq(DiscountNetwork::ResponseObject)
+    end
+  end
 end


### PR DESCRIPTION
Discount Network allow subscriber to resets their password based on a valid reset token, This commit implement the interface so developer can use this API to create the new password for the their existing discount network membership. Usages

``` ruby
DiscountNetwork::Password.create(token, password_attributes)
```
