### PR TITLE
Add `password validation` interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,16 @@ their password using the Discount network API.
 DiscountNetwork::Password.forgot(email_address)
 ```
 
+#### Validate reset token
+
+Before allowing subscriber to reset their password, developer can validate if
+the reset token is valid or not as expired or invalid reset token won't allow
+subscriber to reset their password.
+
+```ruby
+DiscountNetwork::Password.validate(reset_token)
+```
+
 #### Set new password
 
 Once subscriber has submitted a valid reset request and followed the instruction

--- a/lib/discountnetwork/password.rb
+++ b/lib/discountnetwork/password.rb
@@ -6,6 +6,12 @@ module DiscountNetwork
       )
     end
 
+    def validate(token)
+      DiscountNetwork.get_resource(
+        ["account", "resets", token].join("/"),
+      )
+    end
+
     def create(token, attributes)
       DiscountNetwork.put_resource(
         ["account", "passwords", token].join("/"), account: attributes

--- a/lib/discountnetwork/testing/discountnetwork_api.rb
+++ b/lib/discountnetwork/testing/discountnetwork_api.rb
@@ -141,6 +141,15 @@ module DiscountNetworkApi
     )
   end
 
+  def stub_password_validate_api(token)
+    stub_api_response(
+      :get,
+      ["account", "resets", token].join("/"),
+      filename: "empty",
+      status: 204,
+    )
+  end
+
   def stub_unauthorized_dn_api_reqeust(end_point)
     stub_request(:any, api_end_point(end_point)).
       to_return(status: 401, body: "")

--- a/spec/discountnetwork/password_spec.rb
+++ b/spec/discountnetwork/password_spec.rb
@@ -27,4 +27,15 @@ describe DiscountNetwork::Password do
       expect(password.class).to eq(DiscountNetwork::ResponseObject)
     end
   end
+
+  describe ".validate" do
+    it "valides the password reset token" do
+      token = "ABCD_123"
+      stub_password_validate_api(token)
+      password = DiscountNetwork::Password.validate(token)
+
+      expect(password).not_to be_nil
+      expect(password.class).to eq(DiscountNetwork::ResponseObject)
+    end
+  end
 end


### PR DESCRIPTION
Before allowing subscriber to reset their password, third party app might want to validate if the reset token is valid or not. Reset token might expired or invalid, and if they try to update a password with expired token then it won't update anything but return an invalid API response. Usages

``` ruby
DiscountNetwork::Password.validate(reset_token)
```
