### PR TITLE
Add supplementary listing interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,23 @@ then we can allow them to set their password as follow
 DiscountNetwork::Password.create(reset_token, password_attributes)
 ```
 
+### Supplementary
+
+Each Discount Network subscription comes with varies number of supplementary
+subscribers, that means primary member can add one or more of this friends or
+family member to his subscription. The supplementary API provides an easier
+way to manage the supplementary subscribers. Please note, This interface expects
+that the subscriber has already been authenticated before making any API call.
+
+#### List supplementaries
+
+To list all the supplementary subscribers for the authenticated subscriber
+developer can use the `list` interface for supplementary.
+
+```ruby
+DiscountNetwork::Supplementary.list
+```
+
 ### Destination
 
 #### List destinations

--- a/lib/discountnetwork.rb
+++ b/lib/discountnetwork.rb
@@ -9,6 +9,7 @@ require "discountnetwork/booking"
 require "discountnetwork/password"
 require "discountnetwork/activation"
 require "discountnetwork/destination"
+require "discountnetwork/supplementary"
 
 module DiscountNetwork
 end

--- a/lib/discountnetwork/supplementary.rb
+++ b/lib/discountnetwork/supplementary.rb
@@ -1,0 +1,9 @@
+module DiscountNetwork
+  class Supplementary < Base
+    def list
+      DiscountNetwork.get_resource(
+        "supplementaries",
+      ).supplementaries
+    end
+  end
+end

--- a/lib/discountnetwork/testing/discountnetwork_api.rb
+++ b/lib/discountnetwork/testing/discountnetwork_api.rb
@@ -150,6 +150,15 @@ module DiscountNetworkApi
     )
   end
 
+  def stub_supplementary_list_api
+    stub_api_response(
+      :get,
+      "supplementaries",
+      filename: "supplementaries",
+      status: 200,
+    )
+  end
+
   def stub_unauthorized_dn_api_reqeust(end_point)
     stub_request(:any, api_end_point(end_point)).
       to_return(status: 401, body: "")

--- a/spec/discountnetwork/supplementary_spec.rb
+++ b/spec/discountnetwork/supplementary_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+describe DiscountNetwork::Supplementary do
+  describe ".list" do
+    it "lists the supplementaries for authenticated subscriber" do
+      set_account_auth_token("ABCD_123")
+      stub_supplementary_list_api
+      supplementaries = DiscountNetwork::Supplementary.list
+
+      expect(supplementaries.count).to eq(1)
+      expect(supplementaries.first.name).to eq("Mrs. Doe")
+    end
+  end
+
+  def set_account_auth_token(token)
+    DiscountNetwork.configuration.auth_token = token
+  end
+end

--- a/spec/fixtures/supplementaries.json
+++ b/spec/fixtures/supplementaries.json
@@ -1,0 +1,33 @@
+{
+  "supplementaries": [
+    {
+      "first_name": "Mrs.",
+      "middle_name": null,
+      "last_name": "Doe",
+      "spouse_name": null,
+      "company_name": "Impact Services",
+      "company_abbr": "IS",
+      "package_name": "Preferred Platinum",
+      "access_id": "ABCD-123-456",
+      "username": "mrs.doe",
+      "sex": "female",
+      "address": "123 Main Street",
+      "city": "New York",
+      "state": "NY",
+      "zip": "NY123",
+      "country": "US",
+      "email": "mrs.doe@example.com",
+      "phone": "+1 123 456 7890",
+      "status": "Pending",
+      "mobile": null,
+      "office_phone": null,
+      "expiration": 50,
+      "created_at": "27 July, 2015",
+      "role": 1,
+      "subscription_status": "Pending",
+      "name": "Mrs. Doe",
+      "id": 2,
+      "token": null
+    }
+  ]
+}


### PR DESCRIPTION
This commit add the interface to retrieve the supplementaries for the authenticated subscriber. Usages

``` ruby
DiscountNetwork::Supplementary.list
```
