### PR TITLE
Add `create` for supplementary

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,25 @@ developer can use the `list` interface for supplementary.
 DiscountNetwork::Supplementary.list
 ```
 
+#### Add supplementary
+
+To add a new supplementary subscriber with authenticated subscriber's
+subscription developer can use the `create` interface for supplementary.
+
+```ruby
+DiscountNetwork::Supplementary.create(
+  subscriber_attributes
+)
+
+# subscriber attributes
+subscriber_attributes = {
+  first_name: "John",
+  last_name: "Green",
+  phone: "+1 123 345 5678",
+  email: "john.green@example.com"
+}
+```
+
 ### Destination
 
 #### List destinations

--- a/lib/discountnetwork/supplementary.rb
+++ b/lib/discountnetwork/supplementary.rb
@@ -5,5 +5,11 @@ module DiscountNetwork
         "supplementaries",
       ).supplementaries
     end
+
+    def create(attributes)
+      DiscountNetwork.post_resource(
+        "supplementaries", subscriber: attributes
+      )
+    end
   end
 end

--- a/lib/discountnetwork/testing/discountnetwork_api.rb
+++ b/lib/discountnetwork/testing/discountnetwork_api.rb
@@ -159,6 +159,16 @@ module DiscountNetworkApi
     )
   end
 
+  def stub_supplementary_create_api(attributes)
+    stub_api_response(
+      :post,
+      "supplementaries",
+      data: { subscriber: attributes },
+      filename: "supplementary",
+      status: 200,
+    )
+  end
+
   def stub_unauthorized_dn_api_reqeust(end_point)
     stub_request(:any, api_end_point(end_point)).
       to_return(status: 401, body: "")

--- a/spec/discountnetwork/supplementary_spec.rb
+++ b/spec/discountnetwork/supplementary_spec.rb
@@ -12,7 +12,29 @@ describe DiscountNetwork::Supplementary do
     end
   end
 
+  describe ".create" do
+    it "creates a new supplementary subscriber" do
+      set_account_auth_token("ABCD_123")
+      stub_supplementary_create_api(supplementary_attributes)
+      supplementary = DiscountNetwork::Supplementary.create(
+        supplementary_attributes,
+      )
+
+      expect(supplementary).not_to be_nil
+      expect(supplementary.activation_token).not_to be_nil
+    end
+  end
+
   def set_account_auth_token(token)
     DiscountNetwork.configuration.auth_token = token
+  end
+
+  def supplementary_attributes
+    {
+      first_name: "John",
+      last_name: "Green",
+      email: "john.green@example.com",
+      phone: "+1 123 234 345 6789",
+    }
   end
 end

--- a/spec/fixtures/supplementary.json
+++ b/spec/fixtures/supplementary.json
@@ -1,0 +1,21 @@
+{
+  "id": 1234,
+  "company_id": 101,
+  "first_name": "John",
+  "middle_name": null,
+  "last_name": "Doe",
+  "sex": null,
+  "dob": null,
+  "country": null,
+  "role": 123,
+  "email": "john.doe@example.com",
+  "phone": "+1 123 456 789 0123",
+  "username": null,
+  "status": null,
+  "activation_token": "token_123_abcd",
+  "parent_id": 1,
+  "access_kit_id": null,
+  "note": null,
+  "referral_key": null,
+  "referrer_id": null
+}


### PR DESCRIPTION
This commit adds the supplementary creation functionality. So the authenticated subscriber can add additional subscriber with their discount network subscription. Usages

``` ruby
  DiscountNetwork::Supplementary.create(
    subscriber_attributes
  )

  # subscriber attributes
  subscriber_attributes = {
    first_name: "John",
    last_name: "Green",
    phone: "+1 123 345 5678",
    email: "john.green@example.com",
  }
```
