### PR TITLE
Initial release to the RubyGems

### DIFF
--- a/discountnetwork.gemspec
+++ b/discountnetwork.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'discountnetwork/version'
+require "discountnetwork/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "discountnetwork"
@@ -9,14 +9,14 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Abu Nashir"]
   spec.email         = ["abunashir@gmail.com"]
 
-  spec.summary       = %q{A Ruby interface to the Discount Network API}
-  spec.description   = %q{A Ruby interface to the Discount Network API}
+  spec.summary       = "The Ruby interface to the Discount Network API"
+  spec.description   = "The Ruby interface to the Discount Network API"
   spec.homepage      = "https://github.com/discountnetwork/discountnetwork-ruby"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.test_files    = `git ls-files -- {spec}/*`.split("\n")
   spec.require_paths = ["lib"]
+  spec.files         = `git ls-files`.split("\n")
+  spec.test_files    = `git ls-files -- {spec}/*`.split("\n")
 
   spec.add_dependency "rest-client", "~> 1.8"
 

--- a/lib/discountnetwork/version.rb
+++ b/lib/discountnetwork/version.rb
@@ -1,3 +1,3 @@
 module Discountnetwork
-  VERSION = "0.0.1".freeze
+  VERSION = "0.1.0".freeze
 end


### PR DESCRIPTION
This commit prepare the `discountnetwork` gem to release on the RubyGems, starts with version `0.1.0`
